### PR TITLE
ACM-30906: Add AAP automation integration

### DIFF
--- a/deployment/rhacmstackem_deployment.yaml.sh
+++ b/deployment/rhacmstackem_deployment.yaml.sh
@@ -125,6 +125,16 @@ spec:
                   name: rh-offline-token
                   key: token
                   optional: true
+            - name: AAP_OPERATOR_CHANNEL
+              value: "${AAP_OPERATOR_CHANNEL:-stable-2.5-cluster-scoped}"
+            - name: AAP_MODE
+              value: "${AAP_MODE:-platform}"
+            - name: AAP_ENABLE_HUB
+              value: "${AAP_ENABLE_HUB:-false}"
+            - name: AAP_ENABLE_EDA
+              value: "${AAP_ENABLE_EDA:-false}"
+            - name: AAP_CURL_INSECURE
+              value: "${AAP_CURL_INSECURE:-true}"
 EOF
 
 echo ""

--- a/deployment/rhacmstackem_deployment.yaml.sh
+++ b/deployment/rhacmstackem_deployment.yaml.sh
@@ -117,6 +117,14 @@ spec:
               value: "${CLAIM_REUSE}" 
             - name: SCHEDULED_HIBERNATION
               value: "${SCHEDULED_HIBERNATION:-false}"
+            - name: INSTALL_AAP
+              value: "${INSTALL_AAP:-false}"
+            - name: RH_OFFLINE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: rh-offline-token
+                  key: token
+                  optional: true
 EOF
 
 echo ""

--- a/rhacmstackem.sh
+++ b/rhacmstackem.sh
@@ -159,6 +159,15 @@ fi
 # Point to claimed cluster
 export KUBECONFIG=${LIFEGUARD_PATH}/clusterclaims/${CLUSTERCLAIM_NAME}/kubeconfig
 
+# Install Ansible Automation Platform
+if [[ "${INSTALL_AAP:-"false"}" == "true" ]]; then
+  echo "$(date) ##### Installing Ansible Automation Platform"
+  git clone --depth 1 --filter=blob:none --sparse https://github.com/stolostron/console.git
+  pushd console && git sparse-checkout set scripts/aap-automation && popd
+  export RH_OFFLINE_TOKEN="${RH_OFFLINE_TOKEN}"
+  ./console/scripts/aap-automation/aap-install-wrapper.sh || echo "$(date) WARNING: AAP installation failed (non-blocking)"
+fi
+
 # Send cluster information to Slack
 if [[ -n "${SLACK_URL}" ]] || ( [[ -n "${SLACK_TOKEN}" ]] && [[ -n "${SLACK_CHANNEL_ID}" ]] ); then
   echo "$(date) ##### Posting information to Slack"

--- a/rhacmstackem.sh
+++ b/rhacmstackem.sh
@@ -159,12 +159,16 @@ fi
 # Point to claimed cluster
 export KUBECONFIG=${LIFEGUARD_PATH}/clusterclaims/${CLUSTERCLAIM_NAME}/kubeconfig
 
-# Install Ansible Automation Platform
+# Install Ansible Automation Platform (opt-in, requires RH_OFFLINE_TOKEN)
 if [[ "${INSTALL_AAP:-"false"}" == "true" ]]; then
   echo "$(date) ##### Installing Ansible Automation Platform"
   git clone --depth 1 --filter=blob:none --sparse https://github.com/stolostron/console.git
   pushd console && git sparse-checkout set scripts/aap-automation && popd
-  export RH_OFFLINE_TOKEN="${RH_OFFLINE_TOKEN}"
+  export OPERATOR_CHANNEL="${AAP_OPERATOR_CHANNEL:-stable-2.5-cluster-scoped}"
+  export AAP_MODE="${AAP_MODE:-platform}"
+  export ENABLE_HUB="${AAP_ENABLE_HUB:-false}"
+  export ENABLE_EDA="${AAP_ENABLE_EDA:-false}"
+  export CURL_INSECURE="${AAP_CURL_INSECURE:-true}"
   ./console/scripts/aap-automation/install-aap.sh || echo "$(date) WARNING: AAP installation failed (non-blocking)"
 fi
 

--- a/rhacmstackem.sh
+++ b/rhacmstackem.sh
@@ -165,7 +165,7 @@ if [[ "${INSTALL_AAP:-"false"}" == "true" ]]; then
   git clone --depth 1 --filter=blob:none --sparse https://github.com/stolostron/console.git
   pushd console && git sparse-checkout set scripts/aap-automation && popd
   export RH_OFFLINE_TOKEN="${RH_OFFLINE_TOKEN}"
-  ./console/scripts/aap-automation/aap-install-wrapper.sh || echo "$(date) WARNING: AAP installation failed (non-blocking)"
+  ./console/scripts/aap-automation/install-aap.sh || echo "$(date) WARNING: AAP installation failed (non-blocking)"
 fi
 
 # Send cluster information to Slack


### PR DESCRIPTION
## Summary

Integrates automated Ansible Automation Platform (AAP) provisioning into the rhacmstackem workflow. When enabled, AAP is installed on the weekly cluster after RHACM deployment and certificate setup, making it available for the team without manual intervention.

Companion PR: https://github.com/stolostron/console/pull/5956 (adds `install-aap.sh` to the console repo)

## Changes

### `rhacmstackem.sh`
- **Shallow sparse clone** of `stolostron/console` to fetch only the `scripts/aap-automation/` directory (~few MB instead of hundreds)
- Calls `install-aap.sh` **after certificate setup**, before Slack notification
- Gated behind `INSTALL_AAP=true` — no effect on existing workflows when unset
- **Non-blocking** — AAP installation failure logs a warning but does not fail the overall run
- **Maps CronJob env vars** to `install-aap.sh` variable names (e.g., `AAP_OPERATOR_CHANNEL` → `OPERATOR_CHANNEL`), so all AAP configuration can be controlled from the deployment YAML

### `deployment/rhacmstackem_deployment.yaml.sh`
- Adds `INSTALL_AAP` environment variable (default: `false`)
- Adds `RH_OFFLINE_TOKEN` sourced from an optional Kubernetes secret (`rh-offline-token`)
- Adds AAP configuration variables (see [Configuration Variables](#configuration-variables) below) so operators can customize AAP installation without modifying scripts

## How AAP Installation Works

The `install-aap.sh` script handles the full AAP lifecycle on an OpenShift cluster:

### 1. Idempotency Check
Before doing anything, the script checks the current state of AAP on the cluster:
- **Healthy** → logs the existing route URL and exits `0` (safe to re-run)
- **Not installed** → proceeds with full installation
- **Namespace exists, no CR** → resumes installation from where it left off
- **Unhealthy** → attempts repair by reapplying the CR

### 2. Operator Installation
- Creates the `ansible-automation-platform` namespace
- Applies an `OperatorGroup` and `Subscription` to install the AAP operator from OperatorHub
- Waits up to 5 minutes for the operator CSV to reach `Succeeded`

### 3. Platform Deployment
- Creates either an `AnsibleAutomationPlatform` CR (default, full platform with Gateway UI) or a legacy `AutomationController` CR, controlled by `AAP_MODE`
- Optional components: Hub (private Ansible content) and EDA (event-driven automation) can be enabled via `AAP_ENABLE_HUB` / `AAP_ENABLE_EDA`
- Waits up to 15 minutes for the CR to report `Running=True`

### 4. Credential Retrieval
- Reads the admin password from the `<platform-name>-admin-password` secret
- Discovers the platform route URL

### 5. Subscription Management (optional)
When `RH_OFFLINE_TOKEN` is provided, the script fully automates subscription setup:
1. Exchanges the offline token for a short-lived access token via Red Hat SSO
2. Checks for an existing subscription allocation (by name) or creates a new one
3. Finds an available AAP subscription pool and attaches it to the allocation
4. Downloads the subscription manifest ZIP from the Red Hat API
5. Uploads the manifest to the AAP controller API

When no token is provided, installation completes without a subscription — it can be attached manually later.

### 6. OAuth Token & ACM Credential
- Generates an OAuth2 token via the AAP Controller API for external integrations
- Stores the token in a Kubernetes secret (`<platform-name>-oauth-token`)
- Creates an ACM Ansible credential (`aap-shared-credential`) with discovery labels (`cluster.open-cluster-management.io/type: "ans"`), so AAP is usable from ACM immediately without manual credential setup

### 7. Summary
Prints the AAP URL, namespace, mode, deployed components, ACM credential name, and `oc` commands to retrieve the admin password, OAuth token, and ACM credential secret.

## Configuration Variables

All AAP configuration variables are exposed in the CronJob deployment YAML (`deployment/rhacmstackem_deployment.yaml.sh`), allowing operators to customize AAP installation directly from the deployment without modifying any scripts. The CronJob passes these values as environment variables to the container, and `rhacmstackem.sh` maps them to the names expected by `install-aap.sh`.

| CronJob Variable | Maps to (install-aap.sh) | Default | Description |
|---|---|---|---|
| `INSTALL_AAP` | _(used directly)_ | `false` | Enable/disable AAP installation entirely |
| `RH_OFFLINE_TOKEN` | _(used directly)_ | _(empty)_ | Red Hat offline token for automated subscription management. Sourced from a Kubernetes secret (`rh-offline-token`). When not provided, AAP installs without a subscription. |
| `AAP_OPERATOR_CHANNEL` | `OPERATOR_CHANNEL` | `stable-2.5-cluster-scoped` | OLM subscription channel for the AAP operator. Controls which version of the AAP operator is installed from OperatorHub. |
| `AAP_MODE` | `AAP_MODE` | `platform` | Deployment mode. `platform` installs the full AAP with Gateway UI; `controller` installs only the Automation Controller (API-only, no Gateway). |
| `AAP_ENABLE_HUB` | `ENABLE_HUB` | `false` | Deploy Private Automation Hub alongside AAP. Provides a local repository for Ansible content (collections, execution environments). |
| `AAP_ENABLE_EDA` | `ENABLE_EDA` | `false` | Deploy Event-Driven Ansible (EDA) Controller. Enables event-driven automation workflows that trigger playbook runs from external events. |
| `AAP_CURL_INSECURE` | `CURL_INSECURE` | `true` | Skip TLS certificate verification for AAP API calls. Set to `true` by default because weekly clusters use self-signed certificates. Set to `false` in environments with valid TLS. |

### Variable naming convention

The CronJob uses `AAP_`-prefixed names to avoid collisions with other rhacmstackem environment variables. `rhacmstackem.sh` re-exports them to the names `install-aap.sh` expects:

```bash
export OPERATOR_CHANNEL="${AAP_OPERATOR_CHANNEL:-stable-2.5-cluster-scoped}"
export AAP_MODE="${AAP_MODE:-platform}"
export ENABLE_HUB="${AAP_ENABLE_HUB:-false}"
export ENABLE_EDA="${AAP_ENABLE_EDA:-false}"
export CURL_INSECURE="${AAP_CURL_INSECURE:-true}"
```

## Test Plan

- [x] Run rhacmstackem with `INSTALL_AAP=false` (default) — verify no AAP-related activity
- [x] Run rhacmstackem with `INSTALL_AAP=true` — verify AAP installs after cert setup
- [x] Run rhacmstackem with `INSTALL_AAP=true` and `RH_OFFLINE_TOKEN` set — verify subscription is attached automatically
- [ ] Re-run on a cluster with AAP already installed — verify idempotent skip
- [x] Simulate AAP install failure — verify rhacmstackem continues and posts to Slack
- [ ] Verify ACM Ansible credential (`aap-shared-credential`) is created and visible in ACM credentials page
- [ ] Override `AAP_OPERATOR_CHANNEL` — verify install-aap.sh uses the custom channel
- [ ] Set `AAP_MODE=controller` — verify only Automation Controller is deployed (no Gateway)